### PR TITLE
fix: filter options to don't show storybook to vue 2 with typescript + templates bugfixes

### DIFF
--- a/src/actions/guided.js
+++ b/src/actions/guided.js
@@ -203,7 +203,9 @@ export async function guidedAction() {
     })
   }
 
-  if (['component'].includes(type)) {
+  const isVue2TypeScript = framework === FrameworkEnum.vue && version === 2 && typescript
+
+  if (['component'].includes(type) && !isVue2TypeScript) {
     withStory = await confirm({
       message: 'Would you like to add storybook story?'
     })
@@ -315,6 +317,7 @@ function getPathChoices({ type, target }) {
 function showPreview(answers) {
   const askedQuestions = {
     'Framework/Lib': answers.framework,
+    'Framework/Lib Version': answers.version,
     'Resource Type': answers.type,
     'Resource Name': answers.name,
     'With TypeScript': boolAsText(answers.typescript),

--- a/src/constants/templates.js
+++ b/src/constants/templates.js
@@ -49,8 +49,8 @@ export const frameworkTemplates = {
           options: {
             css_modules: 'templates/vue/2/js/component/CssModulesOptions.vue',
             scss: 'templates/vue/2/js/component/ScssOptions.vue',
-            no_style: 'templates/vue/2/js/component/OptionsWithStyle.vue',
-            vanilla_css: 'templates/vue/2/js/component/Options.vue',
+            no_style: 'templates/vue/2/js/component/Options.vue',
+            vanilla_css: 'templates/vue/2/js/component/OptionsWithStyle.vue',
             tailwind_inline: 'templates/vue/2/js/component/TailwindInlineOptions.vue',
             tailwind_file: 'templates/vue/2/js/component/TailwindOptions.vue'
           }
@@ -59,8 +59,8 @@ export const frameworkTemplates = {
           options: {
             css_modules: 'templates/vue/2/js/page/CssModulesOptions.vue',
             scss: 'templates/vue/2/js/page/ScssOptions.vue',
-            no_style: 'templates/vue/2/js/page/OptionsWithStyle.vue',
-            vanilla_css: 'templates/vue/2/js/page/Options.vue',
+            no_style: 'templates/vue/2/js/page/Options.vue',
+            vanilla_css: 'templates/vue/2/js/page/OptionsWithStyle.vue',
             tailwind_inline: 'templates/vue/2/js/page/TailwindInlineOptions.vue',
             tailwind_file: 'templates/vue/2/js/page/TailwindOptions.vue'
           }
@@ -71,8 +71,8 @@ export const frameworkTemplates = {
           options: {
             css_modules: 'templates/vue/2/ts/component/CssModulesOptions.vue',
             scss: 'templates/vue/2/ts/component/ScssOptions.vue',
-            no_style: 'templates/vue/2/ts/component/OptionsWithStyle.vue',
-            vanilla_css: 'templates/vue/2/ts/component/Options.vue',
+            no_style: 'templates/vue/2/ts/component/Options.vue',
+            vanilla_css: 'templates/vue/2/ts/component/OptionsWithStyle.vue',
             tailwind_inline: 'templates/vue/2/ts/component/TailwindInlineOptions.vue',
             tailwind_file: 'templates/vue/2/ts/component/TailwindOptions.vue'
           }
@@ -81,8 +81,8 @@ export const frameworkTemplates = {
           options: {
             css_modules: 'templates/vue/2/ts/page/CssModulesOptions.vue',
             scss: 'templates/vue/2/ts/page/ScssOptions.vue',
-            no_style: 'templates/vue/2/ts/page/OptionsWithStyle.vue',
-            vanilla_css: 'templates/vue/2/ts/page/Options.vue',
+            no_style: 'templates/vue/2/ts/page/Options.vue',
+            vanilla_css: 'templates/vue/2/ts/page/OptionsWithStyle.vue',
             tailwind_inline: 'templates/vue/2/ts/page/TailwindInlineOptions.vue',
             tailwind_file: 'templates/vue/2/ts/page/TailwindOptions.vue'
           }


### PR DESCRIPTION
- Don't show Storybook if is Vue 2 with TS
- Fix swaped templates causing styled templates with None style option selected
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.6.0--canary.23.c28f778.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install clingon@0.6.0--canary.23.c28f778.0
  # or 
  yarn add clingon@0.6.0--canary.23.c28f778.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
