### PR TITLE
fix: add validation for empty custom paths

### DIFF
--- a/src/actions/guided.js
+++ b/src/actions/guided.js
@@ -153,7 +153,8 @@ export async function guidedAction() {
 
   if (!choices || resourcePath === 'type-path') {
     resourcePath = await input({
-      message: `What is the folder path that I should create your ${type} in? e.g. src/folder/here`
+      message: `What is the folder path that I should create your ${type} in? e.g. src/folder/here`,
+      validate: pathValidator
     })
   }
 
@@ -182,7 +183,8 @@ export async function guidedAction() {
 
     if (!choices || testPath === 'type-path') {
       testPath = await input({
-        message: 'What is the folder path that I should create your tests in? e.g. folder/here'
+        message: 'What is the folder path that I should create your tests in? e.g. folder/here',
+        validate: pathValidator
       })
     }
 
@@ -230,7 +232,8 @@ export async function guidedAction() {
 
     if (!choices || storyPath === 'type-path') {
       storyPath = await input({
-        message: 'What is the folder path that I should create your story in? e.g. folder/here'
+        message: 'What is the folder path that I should create your story in? e.g. folder/here',
+        validate: pathValidator
       })
     }
   }
@@ -343,4 +346,11 @@ function getCssApproachName(target) {
   const option = cssFrameworkChoices.find(({ value }) => value && value === target)
 
   return option?.name
+}
+
+/**
+ * Path validator for inquirer `input()`
+ */
+function pathValidator(value) {
+  return value ?? 'Enter an existing path. For root dir, use "."'
 }

--- a/src/actions/guided.js
+++ b/src/actions/guided.js
@@ -3,19 +3,18 @@ import {
   frameworksAndLibsChoices,
   jsTypeChoices,
   testPostfixChoices,
-  resourcesPaths,
   tsTypeChoices,
   vueVersionsChoices,
-  storiesPostfixChoices,
   testFrameworkChoices,
   cssFrameworkChoices,
   chooseMyOwnPathChoice
 } from '../constants/choices.js'
 
-import { boolAsText } from '../utils/string.js'
 import { guidedFlowGenerator } from '../flows/guided-flow-generator.js'
 
 import { CssFrameworkEnum, FrameworkEnum } from '../enums/frameworks.js'
+
+import { getPathChoices, pathValidator, showPreview } from '../utils/guided-action.js'
 
 export async function guidedAction() {
   /**
@@ -91,7 +90,7 @@ export async function guidedAction() {
    *
    * @type {import("../types.js").CssFramework}
    */
-  let cssFramework = 'vanilla_css'
+  let cssFramework = 'css_vanilla'
 
   /**
    * Target version of framework (e.g Vue 2 or 3, etc)
@@ -292,65 +291,4 @@ export async function guidedAction() {
 
     if (doAgain) guidedAction()
   }
-}
-
-/**
- * Get path choices for list on prompt
- *
- * @param {{ type: import("../types.js").Resource, target: }} props
- * @returns {import("../constants/choices.js").TypeChoices[]}
- */
-function getPathChoices({ type, target }) {
-  if (target === 'test') return resourcesPaths.test[type]
-  if (target === 'story') return resourcesPaths.storybook_story[type]
-
-  return resourcesPaths[type]
-}
-
-/**
- * Viewing answers to questions asked to the user
- *
- * @param {import("../types.js").Answers} answers User's responses
- */
-function showPreview(answers) {
-  const askedQuestions = {
-    'Framework/Lib': answers.framework,
-    'Framework/Lib Version': answers.version,
-    'Resource Type': answers.type,
-    'Resource Name': answers.name,
-    'With TypeScript': boolAsText(answers.typescript),
-    'CSS approach': getCssApproachName(answers.cssFramework),
-    'With Story': boolAsText(answers.withStory),
-    'With Unit Test': boolAsText(answers.withTest),
-    'With Testing Library': boolAsText(answers.withTestingLibrary),
-    'My Test Postfix': answers.testPostfix,
-    'My Test Framework': answers.testFramework,
-    'Resource Path': answers.resourcePath,
-    'Test Path': answers.testPath,
-    'Story Path': answers.storyPath
-  }
-
-  const preview = Object.fromEntries(Object.entries(askedQuestions).filter(([_, v]) => v !== null))
-
-  console.table(preview)
-}
-
-/**
- * Css Frameworks
- *
- * @param {import("../types.js").CssFramework} target Css framework
- */
-function getCssApproachName(target) {
-  if (!target) return null
-
-  const option = cssFrameworkChoices.find(({ value }) => value && value === target)
-
-  return option?.name
-}
-
-/**
- * Path validator for inquirer `input()`
- */
-function pathValidator(value) {
-  return value ?? 'Enter an existing path. For root dir, use "."'
 }

--- a/src/constants/choices.js
+++ b/src/constants/choices.js
@@ -2,6 +2,7 @@ import { CssFrameworkEnum, FrameworkEnum, TestFrameworkEnum } from '../enums/fra
 import { VueVersionEnum } from '../enums/vue-version.js'
 import { ResourceTypeEnum } from '../enums/resource-type.js'
 import { StoryPostfixEnum, TestPostfixEnum } from '../enums/postfixes.js'
+import { cssApproachLabels, frameworksLabel, testFrameworksLabel } from './labels.js'
 
 /**
  * @typedef {{ name: import("../types.js").TypeNames, value: import("../types.js").Resource }} TypeChoices
@@ -50,39 +51,63 @@ export const jsTypeChoices = [
  * @type {TestFrameworkChoices[]}
  */
 export const testFrameworkChoices = [
-  { name: 'Jest', value: TestFrameworkEnum.jest },
-  { name: 'Vitest', value: TestFrameworkEnum.vitest }
+  {
+    name: testFrameworksLabel.jest,
+    value: TestFrameworkEnum.jest
+  },
+  {
+    name: testFrameworksLabel.vitest,
+    value: TestFrameworkEnum.vitest
+  }
 ]
 
 /**
  * @type {FrameworkChoices[]}
  */
 export const frameworksAndLibsChoices = [
-  { name: 'Vue', value: FrameworkEnum.vue },
-  { name: 'React', value: FrameworkEnum.react }
+  {
+    name: frameworksLabel.vue,
+    value: FrameworkEnum.vue
+  },
+  {
+    name: frameworksLabel.react,
+    value: FrameworkEnum.react
+  }
 ]
 
 /**
  * @type {CssrameworkChoices[]}
  */
 export const cssFrameworkChoices = [
-  { name: 'None', value: 'no_style' },
-  { name: 'Vanilla Pure CSS (.css)', value: CssFrameworkEnum.vanilla_css },
   {
-    name: 'Tailwind Inline (inside component)',
+    name: cssApproachLabels.no_style,
+    value: CssFrameworkEnum.no_style
+  },
+  {
+    name: cssApproachLabels.css_vanilla,
+    value: CssFrameworkEnum.css_vanilla
+  },
+  {
+    name: cssApproachLabels.tailwind_inline,
     value: CssFrameworkEnum.tailwind_inline
   },
   {
-    name: 'Tailwind (CSS w/ @apply)',
+    name: cssApproachLabels.tailwind_file,
     value: CssFrameworkEnum.tailwind_file
   },
-  { name: 'CSS Modules (.css)', value: CssFrameworkEnum.css_modules },
-  { name: 'SASS (.scss)', value: CssFrameworkEnum.scss }
+  {
+    name: cssApproachLabels.css_modules,
+    value: CssFrameworkEnum.css_modules
+  },
+  {
+    name: cssApproachLabels.scss,
+    value: CssFrameworkEnum.scss
+  }
 ]
 
 export const vueVersionsChoices = [
-  { name: 'Vue 3', value: VueVersionEnum[3] },
-  { name: 'Vue 2', value: VueVersionEnum[2] }
+  { name: '3', value: VueVersionEnum[3] },
+  { name: '2', value: VueVersionEnum[2] }
 ]
 
 export const testPostfixChoices = [

--- a/src/constants/file-extension-map.js
+++ b/src/constants/file-extension-map.js
@@ -26,7 +26,7 @@ export const fileExtensionMap = {
   style: {
     css_modules: 'css',
     tailwind_file: 'css',
-    vanilla_css: 'css',
+    css_vanilla: 'css',
     scss: 'scss'
   }
 }

--- a/src/constants/labels.js
+++ b/src/constants/labels.js
@@ -1,0 +1,28 @@
+/**
+ * @type {Record<import("../types").CssFramework, import("../types").CssFrameworkNames>}
+ */
+export const cssApproachLabels = {
+  css_vanilla: 'CSS Vanilla',
+  css_modules: 'CSS Modules',
+  no_style: 'None',
+  scss: 'Sass/Scss',
+  tailwind_file: 'Tailwind (css file w/ @apply)',
+  tailwind_inline: 'Tailwind (inline w/ class attr)'
+}
+
+/**
+ * @type {Record<import("../types").Framework, import("../types").FrameworkNames>}
+ */
+export const frameworksLabel = {
+  vue: 'Vue',
+  react: 'React',
+  vanilla: 'Vanilla'
+}
+
+/**
+ * @type {Record<import("../types").TestFramework, import("../types").TestFrameworkNames>}
+ */
+export const testFrameworksLabel = {
+  jest: 'Jest',
+  vitest: 'Vitest'
+}

--- a/src/constants/templates.js
+++ b/src/constants/templates.js
@@ -23,7 +23,7 @@ export const frameworkTemplates = {
           no_style: 'templates/react/js/component/Functional.jsx',
           css_modules: 'templates/react/js/component/CssModulesFunctional.jsx',
           scss: 'templates/react/js/component/FunctionalWithScss.jsx',
-          vanilla_css: 'templates/react/js/component/FunctionalWithStyle.jsx',
+          css_vanilla: 'templates/react/js/component/FunctionalWithStyle.jsx',
           tailwind_inline: 'templates/react/js/component/TailwindInlineFunctional.jsx',
           tailwind_file: 'templates/react/js/component/TailwindFunctional.jsx'
         }
@@ -35,7 +35,7 @@ export const frameworkTemplates = {
           no_style: 'templates/react/ts/component/Functional.tsx',
           css_modules: 'templates/react/ts/component/CssModulesFunctional.tsx',
           scss: 'templates/react/ts/component/FunctionalWithScss.tsx',
-          vanilla_css: 'templates/react/ts/component/FunctionalWithStyle.tsx',
+          css_vanilla: 'templates/react/ts/component/FunctionalWithStyle.tsx',
           tailwind_inline: 'templates/react/ts/component/TailwindInlineFunctional.tsx',
           tailwind_file: 'templates/react/ts/component/TailwindFunctional.tsx'
         }
@@ -50,7 +50,7 @@ export const frameworkTemplates = {
             css_modules: 'templates/vue/2/js/component/CssModulesOptions.vue',
             scss: 'templates/vue/2/js/component/ScssOptions.vue',
             no_style: 'templates/vue/2/js/component/Options.vue',
-            vanilla_css: 'templates/vue/2/js/component/OptionsWithStyle.vue',
+            css_vanilla: 'templates/vue/2/js/component/OptionsWithStyle.vue',
             tailwind_inline: 'templates/vue/2/js/component/TailwindInlineOptions.vue',
             tailwind_file: 'templates/vue/2/js/component/TailwindOptions.vue'
           }
@@ -60,7 +60,7 @@ export const frameworkTemplates = {
             css_modules: 'templates/vue/2/js/page/CssModulesOptions.vue',
             scss: 'templates/vue/2/js/page/ScssOptions.vue',
             no_style: 'templates/vue/2/js/page/Options.vue',
-            vanilla_css: 'templates/vue/2/js/page/OptionsWithStyle.vue',
+            css_vanilla: 'templates/vue/2/js/page/OptionsWithStyle.vue',
             tailwind_inline: 'templates/vue/2/js/page/TailwindInlineOptions.vue',
             tailwind_file: 'templates/vue/2/js/page/TailwindOptions.vue'
           }
@@ -72,7 +72,7 @@ export const frameworkTemplates = {
             css_modules: 'templates/vue/2/ts/component/CssModulesOptions.vue',
             scss: 'templates/vue/2/ts/component/ScssOptions.vue',
             no_style: 'templates/vue/2/ts/component/Options.vue',
-            vanilla_css: 'templates/vue/2/ts/component/OptionsWithStyle.vue',
+            css_vanilla: 'templates/vue/2/ts/component/OptionsWithStyle.vue',
             tailwind_inline: 'templates/vue/2/ts/component/TailwindInlineOptions.vue',
             tailwind_file: 'templates/vue/2/ts/component/TailwindOptions.vue'
           }
@@ -82,7 +82,7 @@ export const frameworkTemplates = {
             css_modules: 'templates/vue/2/ts/page/CssModulesOptions.vue',
             scss: 'templates/vue/2/ts/page/ScssOptions.vue',
             no_style: 'templates/vue/2/ts/page/Options.vue',
-            vanilla_css: 'templates/vue/2/ts/page/OptionsWithStyle.vue',
+            css_vanilla: 'templates/vue/2/ts/page/OptionsWithStyle.vue',
             tailwind_inline: 'templates/vue/2/ts/page/TailwindInlineOptions.vue',
             tailwind_file: 'templates/vue/2/ts/page/TailwindOptions.vue'
           }
@@ -96,7 +96,7 @@ export const frameworkTemplates = {
             css_modules: 'templates/vue/3/js/component/CssModulesOptions.vue',
             scss: 'templates/vue/3/js/component/ScssOptions.vue',
             no_style: 'templates/vue/3/js/component/Options.vue',
-            vanilla_css: 'templates/vue/3/js/component/OptionsWithStyle.vue',
+            css_vanilla: 'templates/vue/3/js/component/OptionsWithStyle.vue',
             tailwind_inline: 'templates/vue/3/js/component/TailwindInlineOptions.vue',
             tailwind_file: 'templates/vue/3/js/component/TailwindOptions.vue'
           },
@@ -104,7 +104,7 @@ export const frameworkTemplates = {
             css_modules: 'templates/vue/3/js/component/CssModulesSetup.vue',
             scss: 'templates/vue/3/js/component/ScssSetup.vue',
             no_style: 'templates/vue/3/js/component/Setup.vue',
-            vanilla_css: 'templates/vue/3/js/component/SetupWithStyle.vue',
+            css_vanilla: 'templates/vue/3/js/component/SetupWithStyle.vue',
             tailwind_inline: 'templates/vue/3/js/component/TailwindInlineSetup.vue',
             tailwind_file: 'templates/vue/3/js/component/TailwindSetup.vue'
           }
@@ -114,7 +114,7 @@ export const frameworkTemplates = {
             css_modules: 'templates/vue/3/js/page/CssModulesOptions.vue',
             scss: 'templates/vue/3/js/page/ScssOptions.vue',
             no_style: 'templates/vue/3/js/page/Options.vue',
-            vanilla_css: 'templates/vue/3/js/page/OptionsWithStyle.vue',
+            css_vanilla: 'templates/vue/3/js/page/OptionsWithStyle.vue',
             tailwind_inline: 'templates/vue/3/js/page/TailwindInlineOptions.vue',
             tailwind_file: 'templates/vue/3/js/page/TailwindOptions.vue'
           },
@@ -122,7 +122,7 @@ export const frameworkTemplates = {
             css_modules: 'templates/vue/3/js/page/CssModulesSetup.vue',
             scss: 'templates/vue/3/js/page/ScssSetup.vue',
             no_style: 'templates/vue/3/js/page/Setup.vue',
-            vanilla_css: 'templates/vue/3/js/page/SetupWithStyle.vue',
+            css_vanilla: 'templates/vue/3/js/page/SetupWithStyle.vue',
             tailwind_inline: 'templates/vue/3/js/page/TailwindInlineSetup.vue',
             tailwind_file: 'templates/vue/3/js/page/TailwindSetup.vue'
           }
@@ -134,7 +134,7 @@ export const frameworkTemplates = {
             css_modules: 'templates/vue/3/ts/component/CssModulesOptions.vue',
             scss: 'templates/vue/3/ts/component/ScssOptions.vue',
             no_style: 'templates/vue/3/ts/component/Options.vue',
-            vanilla_css: 'templates/vue/3/ts/component/OptionsWithStyle.vue',
+            css_vanilla: 'templates/vue/3/ts/component/OptionsWithStyle.vue',
             tailwind_file: 'templates/vue/3/ts/component/TailwindOptions.vue',
             tailwind_inline: 'templates/vue/3/ts/component/TailwindInlineOptions.vue'
           },
@@ -142,7 +142,7 @@ export const frameworkTemplates = {
             css_modules: 'templates/vue/3/ts/component/CssModulesSetup.vue',
             scss: 'templates/vue/3/ts/component/ScssSetup.vue',
             no_style: 'templates/vue/3/ts/component/Setup.vue',
-            vanilla_css: 'templates/vue/3/ts/component/SetupWithStyle.vue',
+            css_vanilla: 'templates/vue/3/ts/component/SetupWithStyle.vue',
             tailwind_file: 'templates/vue/3/ts/component/TailwindSetup.vue',
             tailwind_inline: 'templates/vue/3/ts/component/TailwindInlineSetup.vue'
           }
@@ -152,7 +152,7 @@ export const frameworkTemplates = {
             css_modules: 'templates/vue/3/ts/page/CssModulesOptions.vue',
             scss: 'templates/vue/3/ts/page/ScssOptions.vue',
             no_style: 'templates/vue/3/ts/page/Options.vue',
-            vanilla_css: 'templates/vue/3/ts/page/OptionsWithStyle.vue',
+            css_vanilla: 'templates/vue/3/ts/page/OptionsWithStyle.vue',
             tailwind_file: 'templates/vue/3/ts/page/TailwindOptions.vue',
             tailwind_inline: 'templates/vue/3/ts/page/TailwindInlineOptions.vue'
           },
@@ -160,7 +160,7 @@ export const frameworkTemplates = {
             css_modules: 'templates/vue/3/ts/page/CssModulesSetup.vue',
             scss: 'templates/vue/3/ts/page/ScssSetup.vue',
             no_style: 'templates/vue/3/ts/page/Setup.vue',
-            vanilla_css: 'templates/vue/3/ts/page/SetupWithStyle.vue',
+            css_vanilla: 'templates/vue/3/ts/page/SetupWithStyle.vue',
             tailwind_file: 'templates/vue/3/ts/page/TailwindSetup.vue',
             tailwind_inline: 'templates/vue/3/ts/page/TailwindInlineSetup.vue'
           }
@@ -256,6 +256,6 @@ export const functionTemplates = {
 export const stylesTemplates = {
   scss: 'templates/styles/Default.scss',
   css_modules: 'templates/styles/Default.css',
-  vanilla_css: 'templates/styles/Default.css',
+  css_vanilla: 'templates/styles/Default.css',
   tailwind_file: 'templates/styles/Tailwind.css'
 }

--- a/src/enums/frameworks.js
+++ b/src/enums/frameworks.js
@@ -22,7 +22,7 @@ export const CssFrameworkEnum = {
   css_modules: 'css_modules',
   tailwind_inline: 'tailwind_inline',
   tailwind_file: 'tailwind_file',
-  vanilla_css: 'vanilla_css',
+  css_vanilla: 'css_vanilla',
   scss: 'scss',
   no_style: 'no_style'
 }

--- a/src/flows/guided-flow-generator.js
+++ b/src/flows/guided-flow-generator.js
@@ -120,7 +120,7 @@ async function handleStories(data, path) {
  *
  */
 async function handleStyles(data, path) {
-  if (data.cssFramework === 'no_style') return
+  if (['no_style', 'tailwind_inline'].includes(data.cssFramework)) return
 
   if (data.storyPath === data.resourcePath) {
     return generateStyle({ ...data, path })

--- a/src/generators/css-styles.js
+++ b/src/generators/css-styles.js
@@ -19,8 +19,6 @@ import { StylePostfixEnum } from '../enums/postfixes.js'
  * @param {Answers & { path: string }} answers Answers prompted to the user
  */
 export function generateStyle(answers) {
-  if (answers.cssFramework === 'tailwind_inline') return
-
   const { success, path } = compose(
     defineStyleTemplate(answers),
     getTemplateContent,

--- a/src/generators/css-styles.js
+++ b/src/generators/css-styles.js
@@ -19,7 +19,9 @@ import { StylePostfixEnum } from '../enums/postfixes.js'
  * @param {Answers & { path: string }} answers Answers prompted to the user
  */
 export function generateStyle(answers) {
-  const { success, error, path } = compose(
+  if (answers.cssFramework === 'tailwind_inline') return
+
+  const { success, path } = compose(
     defineStyleTemplate(answers),
     getTemplateContent,
     replaceAllFunctionTextOccurrences,

--- a/src/types.js
+++ b/src/types.js
@@ -42,11 +42,11 @@ import { StoryPostfixEnum, TestPostfixEnum, StylePostfixEnum } from 'enums/postf
  *
  * @typedef {"Page" | "Component" | "Function" | "Type" | "Model" | "Enum" | "Test" | "Spec" | "Cypress Spec" | "Storybook Story"} TypeNames - Resource type names
  *
- * @typedef {"Vue" | "React"} FrameworkNames - Framework names
+ * @typedef {"Vue" | "React" | "Vanilla"} FrameworkNames - Framework names
  *
  * @typedef {"Vitest" | "Jest"} TestFrameworkNames - Test framework Names
  *
- * @typedef {"CSS Modules (.css)" | "Tailwind CSS Inline (inside component)" | "Tailwind CSS w/ File (.css w/ @apply)" | "Vanilla Pure CSS (.css)" | "SASS (.scss)"} CssFrameworkNames - Css Framework names
+ * @typedef {"CSS Modules" | "Tailwind (inline w/ class attr)" | "Tailwind (css file w/ @apply)" | "CSS Vanilla" | "Sass/Scss" | "None"} CssFrameworkNames - Css Framework names
  *
  * @typedef { "2" | "3" } VueVersion - Vue JS versions
  *

--- a/src/utils/file-extension.test.js
+++ b/src/utils/file-extension.test.js
@@ -117,10 +117,10 @@ describe('getFileExtension util', () => {
     assert.strictEqual(extension, 'scss')
   })
 
-  it('make a file extension based on parameters for css styles: vanilla_css', () => {
+  it('make a file extension based on parameters for css styles: css_vanilla', () => {
     const extension = getFileExtension({
       target: 'style',
-      cssFramework: 'vanilla_css'
+      cssFramework: 'css_vanilla'
     })
 
     assert.strictEqual(extension, 'css')

--- a/src/utils/guided-action.js
+++ b/src/utils/guided-action.js
@@ -1,0 +1,63 @@
+import { boolAsText } from './string.js'
+
+import { resourcesPaths } from '../constants/choices.js'
+import { cssApproachLabels } from '../constants/labels.js'
+
+/**
+ * Get path choices for list on prompt
+ *
+ * @param {{ type: import("../types.js").Resource, target: "test" | "story" }} props
+ * @returns {import("../constants/choices.js").TypeChoices[]}
+ */
+export function getPathChoices({ type, target }) {
+  if (target === 'test') return resourcesPaths.test[type]
+  if (target === 'story') return resourcesPaths.storybook_story[type]
+
+  return resourcesPaths[type]
+}
+
+/**
+ * Viewing answers to questions asked to the user
+ *
+ * @param {import("../types.js").Answers} answers User's responses
+ */
+export function showPreview(answers) {
+  const askedQuestions = {
+    'Framework/Lib': answers.framework,
+    'Framework/Lib Version': answers.version,
+    'Resource Type': answers.type,
+    'Resource Name': answers.name,
+    'With TypeScript': boolAsText(answers.typescript),
+    'CSS approach': getCssApproachName(answers.cssFramework),
+    'With Story': boolAsText(answers.withStory),
+    'With Unit Test': boolAsText(answers.withTest),
+    'With Testing Library': boolAsText(answers.withTestingLibrary),
+    'My Test Postfix': answers.testPostfix,
+    'My Test Framework': answers.testFramework,
+    'Resource Path': answers.resourcePath,
+    'Test Path': answers.testPath,
+    'Story Path': answers.storyPath
+  }
+
+  const preview = Object.fromEntries(Object.entries(askedQuestions).filter(([_, v]) => v !== null))
+
+  console.table(preview)
+}
+
+/**
+ * Css Frameworks
+ *
+ * @param {import("../types.js").CssFramework} target Css framework
+ */
+export function getCssApproachName(target) {
+  if (!target) return null
+
+  return cssApproachLabels[target]
+}
+
+/**
+ * Path validator for inquirer `input()`
+ */
+export function pathValidator(value) {
+  return !value ? 'Enter an existing path. For root dir, use "."' : true
+}

--- a/src/utils/guided-action.test.js
+++ b/src/utils/guided-action.test.js
@@ -1,0 +1,130 @@
+import assert from 'node:assert/strict'
+import { describe, it, mock } from 'node:test'
+
+const consoleMock = mock.method(console, 'table').mock
+
+import { getCssApproachName, getPathChoices, pathValidator, showPreview } from './guided-action.js'
+import { cssApproachLabels } from '../constants/labels.js'
+import { resourcesPaths } from '../constants/choices.js'
+
+describe('Guided Action Utils', () => {
+  describe('getCssApproachName util', () => {
+    it('get css approach name', () => {
+      const cssModules = getCssApproachName('css_modules')
+      const scss = getCssApproachName('scss')
+      const vanilla = getCssApproachName('css_vanilla')
+      const noStyle = getCssApproachName('no_style')
+      const tailwindInline = getCssApproachName('tailwind_inline')
+      const tailwindFile = getCssApproachName('tailwind_file')
+
+      assert.strictEqual(cssModules, cssApproachLabels.css_modules)
+      assert.strictEqual(scss, cssApproachLabels.scss)
+      assert.strictEqual(vanilla, cssApproachLabels.css_vanilla)
+      assert.strictEqual(noStyle, cssApproachLabels.no_style)
+      assert.strictEqual(tailwindInline, cssApproachLabels.tailwind_inline)
+      assert.strictEqual(tailwindFile, cssApproachLabels.tailwind_file)
+    })
+  })
+
+  describe('showpreview util', () => {
+    const preview = {
+      cssFramework: 'css_modules',
+      framework: 'react',
+      name: 'test',
+      resourcePath: 'resourcePath',
+      storyPath: 'storyPath',
+      storyPostfix: 'stories',
+      testFramework: 'jest',
+      testPath: 'testPath',
+      testPostfix: 'spec',
+      type: 'component',
+      typescript: true,
+      version: 3,
+      withStory: true,
+      withTest: true,
+      withTestingLibrary: true
+    }
+
+    it('show preview data on `console.table()`', () => {
+      let result
+
+      consoleMock.mockImplementation((value) => {
+        result = value
+      })
+
+      showPreview(preview)
+
+      assert.strict(result, preview)
+    })
+  })
+
+  describe('pathValidator util', () => {
+    it('validate path and return message if empty', () => {
+      const result = pathValidator('')
+
+      assert.strictEqual(result, 'Enter an existing path. For root dir, use "."')
+    })
+
+    it('validate path and return true if has content', () => {
+      const result = pathValidator('src/actions')
+
+      assert.strictEqual(result, true)
+    })
+  })
+
+  describe('getPathChoices util', () => {
+    it('get test path choices to list on prompt', () => {
+      const result = getPathChoices({ type: 'component', target: 'test' })
+
+      assert.strictEqual(result, resourcesPaths.test['component'])
+    })
+
+    it('get story path choices to list on prompt', () => {
+      const result = getPathChoices({ type: 'component', target: 'story' })
+
+      assert.strictEqual(result, resourcesPaths.storybook_story['component'])
+    })
+
+    it('get component path choices to list on prompt', () => {
+      const result = getPathChoices({ type: 'component' })
+
+      assert.strictEqual(result, resourcesPaths.component)
+    })
+
+    it('get function path choices to list on prompt', () => {
+      const result = getPathChoices({ type: 'function' })
+
+      assert.strictEqual(result, resourcesPaths.function)
+    })
+
+    it('get page path choices to list on prompt', () => {
+      const result = getPathChoices({ type: 'page' })
+
+      assert.strictEqual(result, resourcesPaths.page)
+    })
+
+    it('get model path choices to list on prompt', () => {
+      const result = getPathChoices({ type: 'model' })
+
+      assert.strictEqual(result, resourcesPaths.model)
+    })
+
+    it('get type path choices to list on prompt', () => {
+      const result = getPathChoices({ type: 'type' })
+
+      assert.strictEqual(result, resourcesPaths.type)
+    })
+
+    it('get enum path choices to list on prompt', () => {
+      const result = getPathChoices({ type: 'enum' })
+
+      assert.strictEqual(result, resourcesPaths.enum)
+    })
+
+    it('get cypress_spec path choices to list on prompt', () => {
+      const result = getPathChoices({ type: 'cypress_spec' })
+
+      assert.strictEqual(result, resourcesPaths.cypress_spec)
+    })
+  })
+})


### PR DESCRIPTION
- Adding validation for empty custom paths
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.7.2--canary.34.784db4f.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install clingon@0.7.2--canary.34.784db4f.0
  # or 
  yarn add clingon@0.7.2--canary.34.784db4f.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
