### PR TITLE
fix: split path error on not nested paths

### DIFF
--- a/src/utils/string.js
+++ b/src/utils/string.js
@@ -6,7 +6,7 @@
  */
 export function splitPathString(path) {
   if (!path?.includes('/')) {
-    throw new Error('Should pass a string with slash separator, like a folder tree path')
+    return [path]
   }
 
   return path.split('/')


### PR DESCRIPTION
- Fixing error with slash separator
  - When doesn't have nested paths, return same path inside an array
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.7.3--canary.35.a3544d9.1</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install clingon@0.7.3--canary.35.a3544d9.1
  # or 
  yarn add clingon@0.7.3--canary.35.a3544d9.1
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
