### PR TITLE
fix: remove double check on path validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /node_modules
 /pages
+/components
 /dist
 /build
 /lib

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 /node_modules
 /pages
 /components
+/src/pages
+/src/components
 /dist
 /build
 /lib

--- a/src/flows/guided-flow-generator.js
+++ b/src/flows/guided-flow-generator.js
@@ -56,7 +56,7 @@ export async function guidedFlowGenerator(data) {
  * @returns {Promise<string>}
  */
 async function checkProvidedPathRecursive(path, callback, target) {
-  const pathArray = path === currentRootPath ? [path] : splitPathString(path)
+  const pathArray = splitPathString(path)
   const pathExists = checkDirectoriesTree(pathArray)
 
   if (pathExists) {

--- a/src/utils/string.test.js
+++ b/src/utils/string.test.js
@@ -22,10 +22,12 @@ describe('String Utils', () => {
       assert.deepEqual(stringArray, expectedResult)
     })
 
-    it('throw an error when string does not have slashs', () => {
-      const expectToThrowError = () => splitPathString('my_path_with_slash')
+    it('return a array with not nested paths', () => {
+      const path = 'my_path_with_slash'
 
-      assert.throws(expectToThrowError, Error)
+      const stringArray = splitPathString(path)
+
+      assert.deepEqual(stringArray, [path])
     })
   })
 


### PR DESCRIPTION
- Unnecessary double check, the validation inside method always validate the rootPath corner case
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.7.4--canary.36.2e58be6.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install clingon@0.7.4--canary.36.2e58be6.0
  # or 
  yarn add clingon@0.7.4--canary.36.2e58be6.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
