### PR TITLE
feat: add resource name as arg to avoid prompt

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
 <p align="center">
   <img
-    src="https://github.com/ipetinate/clingon/blob/main/doc/img/clingon.svg"
+    src="https://raw.githubusercontent.com/ipetinate/clingon/main/doc/img/clingon.svg"
     alt="Clingon CLI logo" width="128"  style="display: block; margin: 0 auto;"
     />
 </p>
@@ -12,7 +12,10 @@
 ---
 
 > [!IMPORTANT]
-> Do not publish using local npm, with each PR the [Release CI](https://github.com/ipetinate/clingon/actions/workflows/release.yml) pipeline is executed, ensuring version control, publication and creation of the release and changelog..
+> Do not publish using local npm, with each PR the [Release CI](https://github.com/ipetinate/clingon/actions/workflows/release.yml) pipeline is executed, ensuring version control, publication and creation of the release and changelog.
+
+> [!WARNING]
+> Don't forget to put the correct label before creating the PR, so that auto does not create canaries for code that it doesn't need (docs, internal, etc.) and versioning correctly for the code that needs to be published. To learn about labels, check the following documentation: [Auto Release](https://github.com/ipetinate/clingon/blob/main/doc/AUTO_RELEASE.md).
 
 ---
 
@@ -24,7 +27,15 @@
 
 ## Requirements
 
--
+I did:
+
+- [ ] Unit tests
+- [ ] Code formatting
+- [ ] Documentation with JSDocs
+- [ ] \(Optional) Documentation with Markdown
+- [ ] Local Tests
+- [ ] I tested the canary release
+- [ ] I marked the Issue referring to the code (if you didn't create the branch from the issue)
 
 <!-- Fill in the items made in the task, remembering that it is important to maintain the quality of the project, always try to fill in as much as you can, if it makes sense -->
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,41 @@
+<p align="center">
+  <img
+    src="https://github.com/ipetinate/clingon/blob/main/doc/img/clingon.svg"
+    alt="Clingon CLI logo" width="128"  style="display: block; margin: 0 auto;"
+    />
+</p>
+
+# Clingon Empire | Official Pull Request
+
+> Fill in the fields appropriately so that empire reviewers can validate your work.
+
+---
+
+> [!IMPORTANT]
+> Do not publish using local npm, with each PR the [Release CI](https://github.com/ipetinate/clingon/actions/workflows/release.yml) pipeline is executed, ensuring version control, publication and creation of the release and changelog..
+
+---
+
+## Description
+
+-
+
+<!-- Add a description of the work done so that the Pull Request reviewer can better understand what was done, include as much detail as possible -->
+
+## Requirements
+
+-
+
+<!-- Fill in the items made in the task, remembering that it is important to maintain the quality of the project, always try to fill in as much as you can, if it makes sense -->
+
+## Preview
+
+-
+
+<!-- If possible, post a preview of the work done. It can be a short video, a screenshot, or text terminal output, whatever makes sense. -->
+
+## Canary Release
+
+-
+
+<!-- This area is intended for auto-completion of the "auto" tool that will add the details of the NPM canary release here. Don't put anything after this section, "auto" always adds it to the end of the readme. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -33,6 +33,7 @@ I did:
 - [ ] Code formatting
 - [ ] Documentation with JSDocs
 - [ ] \(Optional) Documentation with Markdown
+- [ ] Documentation on github.com/ipetinate/clingon-dot-dev
 - [ ] Local Tests
 - [ ] I tested the canary release
 - [ ] I marked the Issue referring to the code (if you didn't create the branch from the issue)
@@ -46,7 +47,5 @@ I did:
 <!-- If possible, post a preview of the work done. It can be a short video, a screenshot, or text terminal output, whatever makes sense. -->
 
 ## Canary Release
-
--
 
 <!-- This area is intended for auto-completion of the "auto" tool that will add the details of the NPM canary release here. Don't put anything after this section, "auto" always adds it to the end of the readme. -->

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <img
-    src="https://github.com/ipetinate/clingon/blob/main/doc/img/clingon.svg"
+    src="https://raw.githubusercontent.com/ipetinate/clingon/main/doc/img/clingon.svg"
     alt="Clingon CLI logo" width="256"  style="display: block; margin: 0 auto;"
     />
 </p>

--- a/doc/AUTO_RELEASE.md
+++ b/doc/AUTO_RELEASE.md
@@ -1,0 +1,17 @@
+# Auto Release
+
+To perform versioning, changelog creation and publication on NPM, we use [Auto](https://intuit.github.io/auto/index).
+
+In our GitHub actions, there is one called [Release CI](https://github.com/ipetinate/clingon/actions/workflows/release.yml), which is dedicated to this release stage, where auto comes into action and does all the magic.
+
+Auto uses PR labels to perform semantic versioning:
+
+- They do not publish new versions
+  - `documentation`: used when you update some documentation or readme, something like that, and don't want a new release to be executed.
+  - `internal`: for some internal correction or reorganization, something that does not impact correction or does not change anything in the use of the tool.
+- Who publish new versions (follow semver to use these labels):
+  - `patch`: 0.0.X
+  - `minor`: 0.X.0
+  - `major`: X.0.0
+  - For bug or other issues
+  - `bug`

--- a/src/actions/guided.js
+++ b/src/actions/guided.js
@@ -22,7 +22,7 @@ import {
   saveAnswersAsPreset
 } from '../utils/preset.js'
 
-export async function guidedAction() {
+export async function guidedAction(resourceName) {
   /**
    * Answers from prompt or preset
    *
@@ -59,14 +59,18 @@ export async function guidedAction() {
   if (preset) {
     answers = getPresetFileContent(preset)
 
-    answers.name = await input({
-      message: 'Resource name: ',
-      validate: (value) => {
-        return !value ? 'Invalid. Please enter name!' : true
-      }
-    })
+    if (!resourceName) {
+      answers.name = await input({
+        message: 'Resource name: ',
+        validate: (value) => {
+          return !value ? 'Invalid. Please enter name!' : true
+        }
+      })
+    } else {
+      answers.name = resourceName
+    }
   } else {
-    answers = await promptQuestions()
+    answers = await promptQuestions(resourceName)
   }
 
   if (answers) {
@@ -135,8 +139,10 @@ export async function guidedAction() {
  * Call inquirer prompts
  *
  * @returns {Promise<import('../types.js').Answers>}
+ *
+ * @param {string} resourceName Resource name from command args
  */
-async function promptQuestions() {
+async function promptQuestions(resourceName) {
   /**
    * With unit tests?
    *
@@ -359,14 +365,20 @@ async function promptQuestions() {
 
   /**
    * Resource name (e.g if is a component, should be like `PersonCard`)
-   * @type {string}
+   * @type {string | null}
    */
-  const name = await input({
-    message: 'Name',
-    validate: (value) => {
-      return !value ? 'Invalid. Please enter name!' : true
-    }
-  })
+  let name = null
+
+  if (!resourceName) {
+    name = await input({
+      message: 'Name',
+      validate: (value) => {
+        return !value ? 'Invalid. Please enter name!' : true
+      }
+    })
+  } else {
+    name = resourceName
+  }
 
   /**
    * Result of user's prompted asked questions

--- a/src/main.js
+++ b/src/main.js
@@ -42,7 +42,7 @@ program
 
 program
   .command('gen')
-  .argument('<name>', 'Resource name')
+  .argument('[name]', 'Resource name')
   .action(guidedAction)
   .description('Start a guided flow to generate resources (components, functions, pages, etc)')
 

--- a/src/main.js
+++ b/src/main.js
@@ -42,6 +42,7 @@ program
 
 program
   .command('gen')
+  .argument('<name>', 'Resource name')
   .action(guidedAction)
   .description('Start a guided flow to generate resources (components, functions, pages, etc)')
 


### PR DESCRIPTION
<p align="center">
  <img
    src="https://raw.githubusercontent.com/ipetinate/clingon/main/doc/img/clingon.svg"
    alt="Clingon CLI logo" width="128"  style="display: block; margin: 0 auto;"
    />
</p>

# Clingon Empire | Official Pull Request

> Fill in the fields appropriately so that empire reviewers can validate your work.

---

> [!IMPORTANT]
> Do not publish using local npm, with each PR the [Release CI](https://github.com/ipetinate/clingon/actions/workflows/release.yml) pipeline is executed, ensuring version control, publication and creation of the release and changelog.

> [!WARNING]
> Don't forget to put the correct label before creating the PR, so that auto does not create canaries for code that it doesn't need (docs, internal, etc.) and versioning correctly for the code that needs to be published. To learn about labels, check the following documentation: [Auto Release](https://github.com/ipetinate/clingon/blob/main/doc/AUTO_RELEASE.md).

---

## Description

- Add argument on command, now you can pass the resource name as argument after `gen` command to avoid fill name after prompts
- Add PR template
- Update image URL on markdowns to use raw url

<!-- Add a description of the work done so that the Pull Request reviewer can better understand what was done, include as much detail as possible -->

## Requirements

I did:

- [ ] Unit tests
- [x] Code formatting
- [x] Documentation with JSDocs
- [ ] \(Optional) Documentation with Markdown
- [ ] \(Optional) Documentation on github.com/ipetinate/clingon-dot-dev
- [ ] Local Tests
- [ ] I tested the canary release
- [ ] I marked the Issue referring to the code (if you didn't create the branch from the issue)

<!-- Fill in the items made in the task, remembering that it is important to maintain the quality of the project, always try to fill in as much as you can, if it makes sense -->

## Preview

- Default usage (with no name as first argument)

[Screencast from 2024-05-05 10-45-46.webm](https://github.com/ipetinate/clingon/assets/15758789/0eafe87e-1e4c-432b-8a86-63ec684ca669)

- With name as first argument

[Screencast from 2024-05-05 10-47-51.webm](https://github.com/ipetinate/clingon/assets/15758789/e6b128d9-9282-4559-843b-2cb1cb5cf68b)


<!-- If possible, post a preview of the work done. It can be a short video, a screenshot, or text terminal output, whatever makes sense. -->

## Canary Release

<!-- This area is intended for auto-completion of the "auto" tool that will add the details of the NPM canary release here. Don't put anything after this section, "auto" always adds it to the end of the readme. -->



<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.8.1--canary.43.138d916.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install clingon@0.8.1--canary.43.138d916.0
  # or 
  yarn add clingon@0.8.1--canary.43.138d916.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
