### PR TITLE
fix: Options mode conflicts with preset mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "test:watch": "node --test --watch",
     "test:coverage": "node --test --experimental-test-coverage --test-reporter=lcov --test-reporter-destination=lcov.info",
     "dev": "yarn build && clear && node src/main.js",
-    "dev:npx": "yarn build && npm link && clear && npx clingon gen"
+    "dev:npx": "yarn build && npm link && clear && npx clingon "
   },
   "dependencies": {
     "@inquirer/prompts": "^4.3.2",

--- a/src/actions/create.js
+++ b/src/actions/create.js
@@ -35,11 +35,11 @@ export async function createAction(resourceName, options) {
    */
   let preset = options.preset
 
-  if (!options.type || !options.framework || !options.path) {
-    throw new Error('You did not pass any of the mandatory parameters for Options Mode')
-  }
-
   if (!preset && options.framework) {
+    if (!options.type || !options.framework || !options.path) {
+      throw new Error('You did not pass any of the mandatory parameters for Options Mode')
+    }
+
     let storyPath = options.path
     let withStory = options.story
 

--- a/src/main.js
+++ b/src/main.js
@@ -47,9 +47,9 @@ program
   .command('create')
   .argument('<name>', 'Resource name')
   .option('--preset [preset]', 'Preset name')
-  .option('--type <resourceType>', 'Resource type: "function" | "page" | "component"')
+  .option('--type [resourceType]', 'Resource type: "function" | "page" | "component"')
   .option('--vue-version [vueVersion]', 'Vue version: "2" | "3" (default: 3))', '3')
-  .option('--framework <frameworkName>', 'Framework name for default preset: vue or react')
+  .option('--framework [frameworkName]', 'Framework name for default preset: vue or react')
   .option(
     '--css-framework [cssFramework]',
     'Style approach: "css_modules" | "tailwind_inline" | "tailwind_file" | "css_vanilla" | "scss" (default: no_style)',
@@ -61,7 +61,7 @@ program
     TestFrameworkEnum.vitest
   )
   .option(
-    '--path <resourcePath>',
+    '--path [resourcePath]',
     'Path to resource, use dot (".") to current dir where command is executed'
   )
   .option(


### PR DESCRIPTION
<p align="center">
  <img
    src="https://raw.githubusercontent.com/ipetinate/clingon/main/doc/img/clingon.svg"
    alt="Clingon CLI logo" width="128"  style="display: block; margin: 0 auto;"
    />
</p>

# Clingon Empire | Official Pull Request

> Fill in the fields appropriately so that empire reviewers can validate your work.

---

> [!IMPORTANT]
> Do not publish using local npm, with each PR the [Release CI](https://github.com/ipetinate/clingon/actions/workflows/release.yml) pipeline is executed, ensuring version control, publication and creation of the release and changelog.

> [!WARNING]
> Don't forget to put the correct label before creating the PR, so that auto does not create canaries for code that it doesn't need (docs, internal, etc.) and versioning correctly for the code that needs to be published. To learn about labels, check the following documentation: [Auto Release](https://github.com/ipetinate/clingon/blob/main/doc/AUTO_RELEASE.md).

---

## Description

- Fix conflicts with required props from Options Mode and preset mode

<!-- Add a description of the work done so that the Pull Request reviewer can better understand what was done, include as much detail as possible -->

## Requirements

I did:

- [ ] Unit tests
- [x] Code formatting
- [ ] Documentation with JSDocs
- [ ] \(Optional) Documentation with Markdown
- [ ] Documentation on github.com/ipetinate/clingon-dot-dev
- [x] Local Tests
- [ ] I tested the canary release
- [x] I marked the Issue referring to the code (if you didn't create the branch from the issue)

<!-- Fill in the items made in the task, remembering that it is important to maintain the quality of the project, always try to fill in as much as you can, if it makes sense -->

## Preview

https://github.com/ipetinate/clingon/assets/15758789/2ab47318-64b8-4c50-a3f8-ca85e5c9d117

<!-- If possible, post a preview of the work done. It can be a short video, a screenshot, or text terminal output, whatever makes sense. -->

## Canary Release

<!-- This area is intended for auto-completion of the "auto" tool that will add the details of the NPM canary release here. Don't put anything after this section, "auto" always adds it to the end of the readme. -->
