### PR TITLE
fix: versions

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -27,7 +27,7 @@ const program = new Command()
 program
   .name('clingon')
   .description('CLI to generate files based on templates')
-  .version('0.9.0', '-v, --version', 'Current version')
+  .version('0.9.4', '-v, --version', 'Current version')
 
 /*
  * Guided flow - generate components based on prompt answers


### PR DESCRIPTION
<p align="center">
  <img
    src="https://raw.githubusercontent.com/ipetinate/clingon/main/doc/img/clingon.svg"
    alt="Clingon CLI logo" width="128"  style="display: block; margin: 0 auto;"
    />
</p>

# Clingon Empire | Official Pull Request

> Fill in the fields appropriately so that empire reviewers can validate your work.

---

> [!IMPORTANT]
> Do not publish using local npm, with each PR the [Release CI](https://github.com/ipetinate/clingon/actions/workflows/release.yml) pipeline is executed, ensuring version control, publication and creation of the release and changelog.

> [!WARNING]
> Don't forget to put the correct label before creating the PR, so that auto does not create canaries for code that it doesn't need (docs, internal, etc.) and versioning correctly for the code that needs to be published. To learn about labels, check the following documentation: [Auto Release](https://github.com/ipetinate/clingon/blob/main/doc/AUTO_RELEASE.md).

---

## Description

- Bump versions from code on cli --version command

<!-- Add a description of the work done so that the Pull Request reviewer can better understand what was done, include as much detail as possible -->

## Requirements

I did:

- [ ] Unit tests
- [ ] Code formatting
- [ ] Documentation with JSDocs
- [ ] \(Optional) Documentation with Markdown
- [ ] Documentation on github.com/ipetinate/clingon-dot-dev
- [ ] Local Tests
- [ ] I tested the canary release
- [ ] I marked the Issue referring to the code (if you didn't create the branch from the issue)

<!-- Fill in the items made in the task, remembering that it is important to maintain the quality of the project, always try to fill in as much as you can, if it makes sense -->

## Preview

-

<!-- If possible, post a preview of the work done. It can be a short video, a screenshot, or text terminal output, whatever makes sense. -->

## Canary Release

<!-- This area is intended for auto-completion of the "auto" tool that will add the details of the NPM canary release here. Don't put anything after this section, "auto" always adds it to the end of the readme. -->
